### PR TITLE
set `GHCUP_INSTALL_BASE_PREFIX` for `ghcup install`

### DIFF
--- a/lib/utils.bash
+++ b/lib/utils.bash
@@ -35,8 +35,8 @@ install_version() {
 	ensure_ghcup
 
 	if [[ $tool == "ghc" ]] || { [[ $tool == "hls" ]] && [[ $(ver "$version") -ge $(ver "1.7") ]]; }; then
-		"$(ghcup_bin_dir)/ghcup" install "$tool" "$version" -i "$path"
+		GHCUP_INSTALL_BASE_PREFIX="$(asdf_plugin_path)" "$(ghcup_bin_dir)/ghcup" install "$tool" "$version" -i "$path"
 	else
-		"$(ghcup_bin_dir)/ghcup" install "$tool" "$version" -i "${path}/bin"
+		GHCUP_INSTALL_BASE_PREFIX="$(asdf_plugin_path)" "$(ghcup_bin_dir)/ghcup" install "$tool" "$version" -i "${path}/bin"
 	fi
 }


### PR DESCRIPTION
`GHCUP_INSTALL_BASE_PREFIX` is set when installing ghcup but not when doing `ghcup install`, without which a `.ghcup` will be created under the user's home directory.